### PR TITLE
Example for Taiwan

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 #  my selected PBF (ie. Suriname)
-PBF_URL="https://download.geofabrik.de/south-america/suriname-latest.osm.pbf"
+#PBF_URL="https://download.geofabrik.de/south-america/suriname-latest.osm.pbf"
+PBF_URL="https://download.geofabrik.de/asia/taiwan-latest.osm.pbf"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
 version: '3'
 services: 
   geoserver:
-    image: 'geotekne/geoserver:lime-alpine-2.16.2'
+    #image: 'geotekne/geoserver:lime-alpine-2.16.2'
+    image: 'geotekne/geoserver:lime-buster-2.16.2'
     hostname: geoserver
     env_file:
       - ./geoserver.env
     ports:
       - "8080:8080"
     volumes:
-      - './data/geoserver/data_dir/:/var/local/geoserver'
+      #- './data/geoserver/data_dir/:/var/local/geoserver'
+      - './data/geoserver/data_dir/:/opt/geoserver/data_dir'
     depends_on:
       - postgis
     restart: on-failure

--- a/geoserver.env
+++ b/geoserver.env
@@ -6,6 +6,4 @@
 #GDAL_DATA=$GDAL_PATH/2.1
 #LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jni:/usr/share/java
 #DEBIAN_FRONTEND=noninteractive
-
-
-
+STABLE_EXTENSIONS=css-plugin,feature-pregeneralized-plugin


### PR DESCRIPTION
This PR was created just with purpose of showing which as the files you should change in order to have Taiwan working as expected (when I say expected it's about having the right labels rendered in the tiles)

Essentially the change requires a Geoserver docker container which should include the necessary fonts. Since the default image used is focused on size or technical aspects instead of the functionals, then you will see that in the docker-compose.yml file we have to change the "geoserver flavor" from alpine to buster (that means that instead of using a docker container which is using Alpine as SO, we will be using one using Debian Buster). This change allows to include the required fonts (which in Alpine cannot be installed).
More details on this repo:  https://github.com/geotekne-argentina/docker-geoserver-flavors

Now as the Geoserver image is based on Debian Buster (extending capabilities from Kartoza's geoserver docker image) then we can use all the features available in that "docker distribution", which includes: capability of adding plugins via an external folder, same stuff for fonts, among other features ( for more details, take a look here https://hub.docker.com/r/kartoza/geoserver )

Then, we have to apply 2 small changes: 
1. Add the required (by Buster flavor) enviromental variable called STABLE_EXTENSIONS, and add the 2 used plugins which allow to read correctly the prebundled setup.  This change is done in geoserver.env file.
2. Set also the volume in the docker container to point to the folder used for datadir in Buster-flavor, which is /opt/geoserver/data_dir

With that setup, then Geoserver will be ready for rendering the Taiwan labels as expected.

Finally, in config.sh file, we point to a different PBF_URL.

The steps for getting it working then are really simple (first ./setup-datasets.sh and then ./startup.sh)

WARNING: since the PBF for Taiwan is about 250MB, then the importation process to the Postgis Database takes longer than the default example for Suriname. Once started the dockerization, you should see the logs of the imposm docker container, and wait for the importation process to be ready.

Once running, you should see something like this:

![image](https://github.com/geotekne-argentina/osm-geoserver-postgis/assets/1171099/216fd3ed-2c40-4461-86a8-fa2327a4cb5a)


